### PR TITLE
Added Oauth2 Error response handling which format differs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   include:

--- a/src/Provider/Box.php
+++ b/src/Provider/Box.php
@@ -60,7 +60,7 @@ class Box extends AbstractProvider
      *
      * @throws IdentityProviderException
      * @param  ResponseInterface $response
-     * @param  string $data Parsed response data
+     * @param  array $data Parsed response data
      * @return void
      */
     protected function checkResponse(ResponseInterface $response, $data)
@@ -69,6 +69,16 @@ class Box extends AbstractProvider
             throw new IdentityProviderException(
                 $data['message'],
                 $data['status'],
+                $response
+            );
+        }
+
+        // Handle Oauth2 Error
+        // https://developer.box.com/reference/resources/oauth2-error/
+        if (isset($data['error'], $data['error_description'])) {
+            throw new IdentityProviderException(
+                $data['error_description'],
+                $response->getStatusCode(),
                 $response
             );
         }

--- a/test/src/Provider/BoxTest.php
+++ b/test/src/Provider/BoxTest.php
@@ -144,4 +144,23 @@ class BoxTest extends \PHPUnit_Framework_TestCase
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
         $user = $this->provider->getResourceOwner($token);
     }
+
+    /**
+     * @expectedException \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     */
+    public function testOauth2Error()
+    {
+        $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response->shouldReceive('getBody')->andReturn('{"error": "invalid_grant", "error_description": "Invalid refresh token"}');
+        $response->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $response->shouldReceive('getStatusCode')->andReturn(400);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(1)
+            ->andReturn($response);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('refresh_token', ['refresh_token' => 'mock_refresh_token']);
+    }
 }


### PR DESCRIPTION
It seems there are two error types supported by Box api:
- Common errors https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/ which handled properly
- Oauth2 errors https://developer.box.com/reference/resources/oauth2-error/ which currently are not supported and have different response structure.

This PR provides support for Oauth2 errors.
